### PR TITLE
Add --no-sandbox to usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Forked from [buildkite/puppeteer][buildkiteUrl] and based on
 Puppeteer will need to be launched with:
 
 ```js
-browser.launch({ executablePath: 'google-chrome-stable' })
+browser.launch({ executablePath: 'google-chrome-stable', args: ["--no-sandbox"]})
 ```
 
 This is done by default in [@ianwalter/bff-puppeteer][bffPuppeteerUrl].


### PR DESCRIPTION
Hey @ianwalter, thanks for the great project, I found it super easy to get up and running. 

When trying it out today, setting `uses: ianwalter/puppeteer@3.0.0`, I received:

```
(node:28) UnhandledPromiseRejectionWarning: Error: Failed to launch the browser process!
[0421/193934.218786:ERROR:zygote_host_impl_linux.cc(89)] Running as root without --no-sandbox is not supported. See https://crbug.com/638180.
```

I added `--no-sandbox` to the args when launching Chrome, and everything worked just fine.

This PR adds that to the documentation, let me know if I've missed something!

Thanks again!